### PR TITLE
MySQL8 : Data Initialize, Password Change commands update

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description       'Installs Percona MySQL client and server'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url        'https://github.com/phlipper/chef-percona'
 issues_url        'https://github.com/phlipper/chef-percona/issues'
-version           '0.16.5'
+version           '0.16.6'
 chef_version      '>= 13.0'
 
 depends 'openssl'

--- a/recipes/configure_server.rb
+++ b/recipes/configure_server.rb
@@ -124,8 +124,8 @@ end
 
 # install db to the data directory
 execute 'setup mysql datadir' do
-  command "mysql_install_db --defaults-file=#{percona['main_config_file']} --user=#{user}"
-  not_if "test -f #{datadir}/mysql/user.frm"
+  command "mysqld --defaults-file=#{percona['main_config_file']} --user=#{user}"
+  not_if "test -f #{datadir}/mysql.ibd"
   action :nothing
 end
 
@@ -168,8 +168,8 @@ unless node['percona']['skip_passwords']
   root_pw = passwords.root_password
 
   execute 'Update MySQL root password' do # ~FC009 - `sensitive`
-    command "mysqladmin --user=root --password='' password '#{root_pw}'"
-    only_if "mysqladmin --user=root --password='' version"
+    command "mysqladmin --user=root password '#{root_pw}'"
+    only_if 'mysqladmin --user=root version'
     sensitive true
   end
 end

--- a/templates/grants.sql.erb
+++ b/templates/grants.sql.erb
@@ -6,7 +6,7 @@
   <% [['SELECT', 'mysql.user'], ['SHUTDOWN', '*.*']].each do |priv, loc| %>
 <%= "GRANT #{priv} ON #{loc} TO '#{@debian_user}'@'localhost';" %>
   <% end -%>
-SET PASSWORD FOR '<%= @debian_user %>'@'localhost' = PASSWORD('<%= @debian_password %>');
+ALTER USER '<%= @debian_user %>'@'localhost' = IDENTIFIED BY '<%= @debian_password %>';
 <% end -%>
 
 
@@ -19,7 +19,7 @@ GRANT RELOAD, LOCK TABLES, REPLICATION CLIENT ON *.* TO '<%= node["percona"]["ba
 <% end -%>
 
 # Set the server root password. This should be preseeded by the package installation.
-SET PASSWORD FOR 'root'@'localhost' = PASSWORD('<%= @root_password %>');
+ALTER USER 'root'@'localhost' = IDENTIFIED BY '<%= @root_password %>';
 
 
 FLUSH PRIVILEGES;


### PR DESCRIPTION
_Please add the appropriate [Risk Level label][1] and make sure you've followed the [code review guidelines][2]!_

## JIRA

* [Main JIRA ticket](https://coupadev.atlassian.net/browse/SRE00IN-4115)

## Summary of issue

- Initialization of data directory is changed in mysql8 - https://coupadev.atlassian.net/browse/SRE00IN-3883
- PASSWORD() method is removed from mysql8 - https://coupadev.atlassian.net/browse/SRE00IN-3882

## Summary of change

- Updated the branch with sous-chefs/percona master repo.
- MySQL8 compatible.

## Testing approach

- [ ] Serverspec test (mandatory)
- [ ] Manual test
- [ ] No test (please specify why)

_Please describe your testing approach here. What cases do your tests cover? Did you cover all of the edge cases? What kinds of tests did you write (unit tests? controller tests? integration tests?)? What was your rationale for choosing one kind of test over another for testing each case?_

[1]: https://coupadev.atlassian.net/wiki/display/CD/Guidelines+for+Risk+Levels
[2]: https://coupadev.atlassian.net/wiki/spaces/CO/pages/180696831/Operations+-+Code+Review+Checklist
[3]: https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments
[4]: https://github.com/blog/821

## Generated Reviewers

### Ops Cookbook Review (ops_cookbook)

- [ ] @alokdnb
  - This rule is always triggered
